### PR TITLE
LAC includes the Caribbean

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,7 +1,7 @@
 LAC-IDPM Documentation
 ===================================
 
-**LAC-IDPM** (Latin American Integrated Decarbonization Pathways Model) is an
+**LAC-IDPM** (Latin American and the Caribbean Integrated Decarbonization Pathways Model) is an
 integrated Python/Julia model used to facilitate exploratory analyses of decarbonization
 transformations too sectors at the country level. It
 


### PR DESCRIPTION
Real change to make the point that we need to expand LAC as Latin American and the Caribbean. Important to notice the Caribbean